### PR TITLE
Add support for (rotate [[x y z]]).

### DIFF
--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -60,6 +60,9 @@
 (defn rotate [a [x y z] & block]
   `(:rotate [~a [~x ~y ~z]] ~@block))
 
+(defn rotate [[x y z] & block]
+	`(:rotate [[~x ~y ~z]] ~@block))
+
 (defn scale [[x y z] & block]
   `(:scale [~x ~y ~z] ~@block))
 

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -70,6 +70,12 @@
    (write-block depth block)
    (list (indent depth) "}\n")))
 
+(defmethod write-expr :rotate [depth [form [[x y z]] & block]]
+	(concat
+		(list (indent depth) "rotate ([" x "," y "," z "]) {\n")
+		(write-block depth block)
+		(list (indent depth) "}\n")))
+
 (defmethod write-expr :scale [depth [form [x y z] & block]]
   (concat
    (list (indent depth) "scale ([" x "," y "," z "]) {\n")


### PR DESCRIPTION
This form corresponds with SCAD's rotate([x,y,z]).
