### PR TITLE
added polyhedron() implementation

### DIFF
--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -71,8 +71,11 @@
       [[r1 r2]] `(:cylinder ~(merge fargs {:h h :r1 r1 :r2 r2}))
       [r] `(:cylinder ~(merge fargs {:h h :r r})))))
 
-(defn polyhedron [points faces]
-  `(:polyhedron {:points ~points :faces ~faces}))
+(defn polyhedron
+  ([points faces]
+    `(:polyhedron {:points ~points :faces ~faces}))
+  ([points faces & {:keys [convexity]}]
+    `(:polyhedron {:points ~points :faces ~faces :convexity ~convexity})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; transformations

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -64,10 +64,11 @@
             (if (nil? r) (list ", r1=" r1 ", r2=" r2) (list ", r=" r))
             `(", center=true);\n"))))
 
-(defmethod write-expr :polyhedron [depth [form {:keys [points faces]}]]
+(defmethod write-expr :polyhedron [depth [form {:keys [points faces convexity]}]]
   `(~@(indent depth) "polyhedron ("
     "points=[[" ~(join "], [" (map #(join ", " %1) points)) "]], "
     "faces=[[" ~(join "], [" (map #(join ", " %1) faces)) "]]"
+    ~@(if (nil? convexity) [] [", convexity=" convexity])
     ");\n"))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Hi I was having a play with scad-clj and wanted to use the polyhedron() function but it seems that it's not implemented. There may be a good reason why, but I'm very new to scad-clj/OpenScad so not aware of potential issues.

I've added it and it works for me, and I thought you may be able to use it. I hope this works okay, I've never done a pull request before.

Regards,
Jules
