### PR TITLE
Transformations, resize and scale.

### DIFF
--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -96,9 +96,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; transformations
 
-(defn scale [[x y z] & block]
-  `(:scale [~x ~y ~z] ~@block))
-
 (defn resize[[x y z] & block]
   (let [is-auto (and (keyword? (first block))
                      (= :auto (first block)))

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -105,12 +105,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; transformations
 
-(defmethod write-expr :scale [depth [form [x y z] & block]]
-  (concat
-   (list (indent depth) "scale ([" x ", " y ", " z "]) {\n")
-   (mapcat #(write-expr (+ depth 1) %1) block)
-   (list (indent depth) "}\n")))
-
 (defmethod write-expr :resize [depth [form {:keys [x y z auto]} & block]]
   (concat
    (list (indent depth) "resize ([" x ", " y ", " z "]")


### PR DESCRIPTION
Both scale and resize take an `[ x y z ]` vector like translate. Scale was super simple just like translate.  Resize takes an optional `Auto` argument which can be `true or false` or it can be a vector of true and false for the x, y and z axis, ie.  `[true, false, true]`. 
