### PR TITLE
Add the 'scale' argument to extrude-linear.

### DIFF
--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -183,8 +183,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; other
 
-(defn extrude-linear [{:keys [height twist convexity center] :or {center *center*}} & block]
-  `(:extrude-linear {:height ~height :twist ~twist :convexity ~convexity :center ~center} ~@block))
+(defn extrude-linear [{:keys [height twist convexity center scale] :or {center *center*}} & block]
+  `(:extrude-linear {:height ~height :twist ~twist :convexity ~convexity :center ~center :scale ~scale} ~@block))
 
 (defn extrude-rotate
   ([ block ] `(:extrude-rotate {} ~block))

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -224,11 +224,12 @@
    (mapcat #(write-expr (inc depth) %1) block)
    (list (indent depth) "}\n")))
 
-(defmethod write-expr :extrude-linear [depth [form {:keys [height twist convexity center]} & block]]
+(defmethod write-expr :extrude-linear [depth [form {:keys [height twist convexity center scale]} & block]]
   (concat
    (list (indent depth) "linear_extrude (height=" height)
    (if (nil? twist) [] (list ", twist=" (rad->deg twist)))
    (if (nil? convexity) [] (list ", convexity=" convexity))
+   (if (nil? scale) [] (list ", scale=" scale))
    (when center (list ", center=true"))
    (list "){\n")
 


### PR DESCRIPTION
This seemed to be missing but I needed it to create pyramids.