### PR TITLE
fixing unquote exception when using convexity and adding angle parameter

### DIFF
--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -190,8 +190,8 @@
   ([ block ]
    (let [args (if *fn* {:fn *fn*} {})]
      `(:extrude-rotate ~args ~block)))
-  ([{:keys [convexity]} block]
-   (let [args (merge {:convexity ~convexity}
+  ([{:keys [convexity angle]} block]
+   (let [args (merge {:convexity convexity :angle angle}
                      (if *fn* {:fn *fn*} {}))]
      `(:extrude-rotate ~args ~block))))
 

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -236,11 +236,14 @@
    (mapcat #(write-expr (inc depth) %1) block)
    (list (indent depth) "}\n")))
 
-(defmethod write-expr :extrude-rotate [depth [form {:keys [convexity fn]} & block]]
+(defmethod write-expr :extrude-rotate [depth [form {:keys [convexity fn angle]} & block]]
   (concat
    (list (indent depth) "rotate_extrude (")
-   (if convexity (list "convexity=" convexity))
-   (if fn (list "$fn=" fn))
+   (join ", "
+     (concat
+       (if convexity [(str "convexity=" convexity)])
+       (if angle [(str "angle=" angle )])
+       (if fn [(str "$fn=" fn)])))
    (list ") {\n")
    (mapcat #(write-expr (inc depth) %1) block)
    (list (indent depth) "}\n")))


### PR DESCRIPTION
This does two things:
* Fixes an IllegalStateException when attempting to call extrude-rotate with {:convexity 10}
* Adds the angle parameter to extrude-rotate method so that it matches the current [method signature](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/2D_to_3D_Extrusion#Usage_2)

Note:  I have literally no clue what I am doing with Clojure, so a thorough code review and criticisms are highly desired.

Thanks! 