### PR TITLE
Support for surface()

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OpenSCAD DSL in Clojure
 
 Functions generally mirror [OpenSCAD](http://en.wikibooks.org/wiki/OpenSCAD_User_Manual/The_OpenSCAD_Language), with the following notable exceptions:
 * All angles are in radians
-* All primative forms are centered at the origin
+* All primitive forms are centered at the origin
 
 Releases and dependency information
 ----

--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -195,6 +195,9 @@
                      (if *fn* {:fn *fn*} {}))]
      `(:extrude-rotate ~args ~block))))
 
+(defn surface [filepath & {:keys [convexity center] :or {center *center*}}]
+  `(:surface ~{:filepath filepath :convexity convexity :center center}))
+
 (defn projection [cut & block]
   `(:projection {:cut cut} ~@block))
 

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -218,6 +218,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; other
 
+(defmethod write-expr :surface [depth [form {:keys [filepath convexity center]}]]
+  (concat
+   (list (indent depth) "surface (file = \"" filepath "\""
+         (when convexity (format ", convexity=%d" convexity))
+         (when center ", center=true") ");\n")))
+
 (defmethod write-expr :projection [depth [form {:keys [cut]} & block]]
   (concat
    (list (indent depth) "projection (cut = " cut ") {\n")


### PR DESCRIPTION
Hi. I’d like to use OpenSCAD’s surface() and see no particular reason why it should not be part of scad-clj.

I have tested the function. It behaves as expected with and without the two optional parameters. However, I am new to Clojure and may have missed some macro wizardry. Please advise or edit if it looks amiss.