### PR TITLE
Add module calls and rudimentary module definitions

### DIFF
--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -83,6 +83,9 @@
   `(:call-module-no-block {:module ~(name module)} ~args))
 (defn call-module-with-block [module & args]
   `(:call-module-with-block {:module ~(name module)} ~args))
+(defn define-module [module & body]
+  `(:define-module {:module ~(name module)} ~body))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; 2D
 

--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -79,6 +79,10 @@
 (defn call [function & args]
   `(:call {:function ~(name function)} ~args))
 
+(defn call-module [module & args]
+  `(:call-module-no-block {:module ~(name module)} ~args))
+(defn call-module-with-block [module & args]
+  `(:call-module-with-block {:module ~(name module)} ~args))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; 2D
 

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -77,6 +77,15 @@
   (let [the-args (first args)]
     (list (indent depth) module " (" (make-arguments (vec the-args)) ");\n")))
 
+(defmethod write-expr :define-module [depth [form {:keys [module]} & args]]
+  (let [the-args (butlast (first args))
+        block (list (last (first args)))]
+    (concat
+     (list (indent depth) "module " module "(" (make-arguments (vec the-args)) ") {\n")
+     (write-block depth block)
+     (list (indent depth) "};\n"))))
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; 2D
 

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -64,6 +64,19 @@
 (defmethod write-expr :call [depth [form {:keys [function]} & args]]
   (list (indent depth) function "(" (make-arguments (apply vec args)) ");\n"))
 
+(defmethod write-expr :call-module-with-block [depth [form {:keys [module]} & args]]
+  (let [
+        the-args (butlast (first args))
+        block (list (last (first args)))]
+    (concat
+     (list (indent depth) module " (" (make-arguments (vec the-args)) ") {\n")
+     (write-block depth block)
+     (list (indent depth) "}\n"))))
+
+(defmethod write-expr :call-module-no-block [depth [form {:keys [module]} & args]]
+  (let [the-args (first args)]
+    (list (indent depth) module " (" (make-arguments (vec the-args)) ");\n")))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; 2D
 


### PR DESCRIPTION
Having run into some scaling issues with mere unstructured OpenSCAD code in my fork of the Dactyl keyboard (~34MB OpenSCAD files), I rewrote my most-called Clojure functions as OpenSCAD modules, and then added these functions so I could call them.

It seems from #34 that this may be a direction you've steered away from; but it can't hurt to ask.