### PR TITLE
Support for additional offset() parameters

### DIFF
--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -169,8 +169,20 @@
 (defn hull [ & block]
   `(:hull  ~@block))
 
-(defn offset [r & block]
+(defn- offset-num
+  "A narrow implementation of OpenSCAD’ offset() for radius only."
+  [r & block]
   `(:offset {:r ~r} ~@block))
+
+(defn- offset-map
+  "A broad implementation of OpenSCAD’s offset(), supporting more parameters."
+  [{:keys [r delta chamfer]} & block]
+  `(:offset ~{:r r :delta delta :chamfer chamfer} ~@block))
+
+(defn offset
+  "Implement OpenSCAD’s offset() for two different call signatures."
+  [options & block]
+  (apply (partial (if (map? options) offset-map offset-num) options) block))
 
 (defn minkowski [ & block]
   `(:minkowski ~@block))

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -203,9 +203,15 @@
    (mapcat #(write-expr (inc depth) %1) block)
    (list (indent depth) "}\n")))
 
-(defmethod write-expr :offset [depth [form {:keys [r]} & block]]
+(defmethod write-expr :offset
+  [depth [form {:keys [r delta chamfer] :or {chamfer false}} & block]]
   (concat
-   (list (indent depth) "offset (r = " r ") {\n")
+   (list (indent depth) "offset (")
+   (if r
+     (list "r = " r)
+     (list "delta = " delta))
+   (when chamfer (list ", chamfer=true"))
+   (list ") {\n")
    (mapcat #(write-expr (inc depth) %1) block)
    (list (indent depth) "}\n")))
 

--- a/test/scad_clj/core_test.clj
+++ b/test/scad_clj/core_test.clj
@@ -1,7 +1,17 @@
 (ns scad-clj.core-test
   (:require [clojure.test :refer :all]
-            [scad-clj model text scad]))
+            [scad-clj.model :as model]))
 
-(deftest a-test
-  (testing "Success"
-    (is (= 0 0))))
+(deftest polymorphic-offset
+  (testing "Numeric offset"
+    (is (= (model/offset 2 ::subject)
+           '(:offset {:r 2} ::subject))))
+  (testing "Hash-map offset, radius"
+    (is (= (model/offset {:r 2} ::subject)
+           '(:offset {:r 2 :delta nil :chamfer nil} ::subject))))
+  (testing "Hash-map offset, delta"
+    (is (= (model/offset {:delta 1} ::subject)
+           '(:offset {:r nil :delta 1 :chamfer nil} ::subject))))
+  (testing "Hash-map offset, composite, variary"
+    (is (= (model/offset {:delta 3 :chamfer true} ::subject0 ::subject1)
+           '(:offset {:r nil :delta 3 :chamfer true} ::subject0 ::subject1)))))


### PR DESCRIPTION
The current offset function supports only one of the three parameters that OpenSCAD can use, and it does so in numeric form. This PR adds support for additional parameters on the pattern of other functions already in scad-clj, using a map of keyword arguments in place of the old number.

I have preserved support for the numeric-only call signature and I have _not_ marked it as deprecated. However, I propose that it should be formally deprecated and eventually removed (in v1.0.0) to control cyclomatic complexity.