### PR TITLE
Add support for invert for surface function

### DIFF
--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -214,8 +214,8 @@
                      (if *fn* {:fn *fn*} {}))]
      `(:extrude-rotate ~args ~block))))
 
-(defn surface [filepath & {:keys [convexity center] :or {center *center*}}]
-  `(:surface ~{:filepath filepath :convexity convexity :center center}))
+(defn surface [filepath & {:keys [convexity center invert] :or {center *center*}}]
+  `(:surface ~{:filepath filepath :convexity convexity :center center :invert invert}))
 
 (defn projection [cut & block]
   `(:projection {:cut cut} ~@block))

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -245,11 +245,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; other
 
-(defmethod write-expr :surface [depth [form {:keys [filepath convexity center]}]]
+(defmethod write-expr :surface [depth [form {:keys [filepath convexity center invert]}]]
   (concat
    (list (indent depth) "surface (file = \"" filepath "\""
          (when convexity (format ", convexity=%d" convexity))
-         (when center ", center=true") ");\n")))
+         (when center ", center=true")
+         (when invert ", invert=true")
+         ");\n")))
 
 (defmethod write-expr :projection [depth [form {:keys [cut]} & block]]
   (concat


### PR DESCRIPTION
Apparently, `invert` option missing from current implementation of `surface` function. Bumped into it a couple of days ago.

Doc says it's been supported since 2015.03 and given that current stable version is 2015.03-3 and anyone using OpenSCAD seriously is using fresh dev snapshot regardless, I feel it's safe to implement it.

https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#Surface