### PR TITLE
multmatrix was missing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "https://github.com/farrellm/scad-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.match "0.2.2"]
                  [net.mikera/core.matrix "0.42.1"]])

--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -187,6 +187,9 @@
 (defn minkowski [ & block]
   `(:minkowski ~@block))
 
+(defn multmatrix [m & block]
+  `(:multmatrix ~m ~@block))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Boolean operations
 

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -221,6 +221,16 @@
    (mapcat #(write-expr (inc depth) %1) block)
    (list (indent depth) "}\n")))
 
+(defmethod write-expr :multmatrix [depth [form m & block]]
+  (let [w (fn [s] (str "[" s "]")) ;; wrap
+        co (fn [c] (apply str (interpose "," c)))] ;; put commas in between  
+    (concat
+     (list (indent depth) "multmatrix(")
+     (w (co (map #(w (co %)) m)))
+     (list ") {\n")
+     (mapcat #(write-expr (inc depth) %1) block)
+     (list (indent depth) "}\n"))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Boolean operations
 


### PR DESCRIPTION
Hi,

i was missing the multmatrix function of OpenSCAD, so i made it.
And my Cider version 20190321.2129 complained about Clojure 1.6 and crashed emacs after Jack-In, so i updated to Clojure 1.8.

Nice Project! I had a lot of fun recently with this little library.