### PR TITLE
fix offset-map

### DIFF
--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -177,7 +177,7 @@
 (defn- offset-map
   "A broad implementation of OpenSCAD’s offset(), supporting more parameters."
   [{:keys [r delta chamfer]} & block]
-  `(:offset ~{:r r :delta delta :chamfer chamfer} ~@block))
+  `(:offset {:r ~r :delta ~delta :chamfer ~chamfer} ~@block))
 
 (defn offset
   "Implement OpenSCAD’s offset() for two different call signatures."


### PR DESCRIPTION
Using `offset` with an options map doesn't work.
```clojure
(offset {:delta 5} (square 100 100))
```
currently yields
```openscad
offset (r = {:delta -5, :chamfer true}) {
  square ([100, 100], center=true);
}
```