### PR TITLE
Add support for vector scale parameter in extrude-linear

### DIFF
--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -275,7 +275,10 @@
    (if (nil? twist) [] (list ", twist=" (rad->deg twist)))
    (if (nil? convexity) [] (list ", convexity=" convexity))
    (if (nil? slices) [] (list ", slices=" slices))
-   (if (nil? scale) [] (list ", scale=" scale))
+   (cond
+     (nil? scale) []
+     (sequential? scale) (list ", scale=[" (first scale) ", " (second scale) "]")
+     :else (list ", scale=" scale))
    (when center (list ", center=true"))
    (list "){\n")
 


### PR DESCRIPTION
The current implementation of `extrude-linear` doesn't allow for non-uniform scaling (in the form of a vector `:scale` parameter).  One can work around the problem by specifying the `:scale` parameter as a string (e.g. ` (extrude-linear {:height 19 :scale "[1 2]"})`) but proper handling of vector values would arguably be preferable.