### PR TITLE
Support fn param when generating text

### DIFF
--- a/src/scad_clj/model.clj
+++ b/src/scad_clj/model.clj
@@ -245,7 +245,9 @@
 ;; text
 
 (defn text [text & {:as args}]
-  (let [args (merge {:text text} args)]
+  (let [args (merge {:text text}
+                    (if *fn* {:fn *fn*})
+                    args)]
     `(:text ~args)))
 
 (defn polygon-text [font size text]

--- a/src/scad_clj/scad.clj
+++ b/src/scad_clj/scad.clj
@@ -105,8 +105,9 @@
     ~@(when convexity [", convexity=" convexity])
     ");\n"))
 
-(defmethod write-expr :text [depth [form {:keys [text size font halign valign spacing direction language script]}]]
+(defmethod write-expr :text [depth [form {:keys [text size font halign valign spacing direction language script fn]}]]
   (list (indent depth) "text (\"" text "\""
+        (when fn (str ", $fn=" fn))
         (when size (str ", size=" size))
         (when font (str ", font=\"" font "\""))
         (when halign (str ", halign=\"" halign "\""))


### PR DESCRIPTION
Text should respect `$fn` parameter. Otherwise it renders with default `$fn` and doesn't look smooth when using large font sizes.

https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Text